### PR TITLE
Feature/object profille

### DIFF
--- a/soxspipe/commonutils/create_dispersion_map.py
+++ b/soxspipe/commonutils/create_dispersion_map.py
@@ -762,7 +762,7 @@ class create_dispersion_map(object):
         # x = np.ones(orderPixelTable.shape[0]) * \
         #     self.pinholeFrame.data.shape[1] - orderPixelTable["observed_x"]
         toprow.scatter(orderPixelTable["observed_y"],
-                       x, marker='x', c='red', s=4)
+                       x, marker='o', c='red', s=0.3, alpha=0.6)
 
         # toprow.set_yticklabels([])
         # toprow.set_xticklabels([])
@@ -779,7 +779,7 @@ class create_dispersion_map(object):
         # xfit = np.ones(orderPixelTable.shape[0]) * \
         #     self.pinholeFrame.data.shape[1] - orderPixelTable["fit_x"]
         midrow.scatter(orderPixelTable["fit_y"],
-                       xfit, marker='x', c='blue', s=4)
+                       xfit, marker='o', c='blue', s=1, alpha=0.6)
 
         # midrow.set_yticklabels([])
         # midrow.set_xticklabels([])
@@ -833,7 +833,7 @@ class create_dispersion_map(object):
             "file_path": filePath
         }, ignore_index=True)
 
-        plt.savefig(filePath)
+        plt.savefig(filePath, dpi=720)
 
         self.log.debug('completed the ``fit_polynomials`` method')
         return xcoeff, ycoeff, res_plots

--- a/soxspipe/commonutils/detect_continuum.py
+++ b/soxspipe/commonutils/detect_continuum.py
@@ -264,7 +264,7 @@ class _base_detect(object):
         # FITTED POSITIONS
         xfit = poly(
             orderPixelTable, *coeff)
-        res = abs(xfit - orderPixelTable[xCol].values)
+        res = xfit - orderPixelTable[xCol].values
 
         # GET UNIQUE VALUES IN COLUMN
         uniqueorders = len(orderPixelTable['order'].unique())

--- a/soxspipe/commonutils/detect_order_edges.py
+++ b/soxspipe/commonutils/detect_order_edges.py
@@ -510,8 +510,8 @@ class detect_order_edges(_base_detect):
         index = int(len(xcoords) / 2)
         x = xcoords[index]
         y = ycoords[index]
-        slice = cut_image_slice(log=self.log, frame=self.flatFrame,
-                                width=sliceWidth, length=sliceLength, x=x, y=y, median=True, plot=False)
+        slice, x_offset, y_centre = cut_image_slice(log=self.log, frame=self.flatFrame,
+                                                    width=sliceWidth, length=sliceLength, x=x, y=y, median=True, plot=False)
         # SMOOTH WITH A MEDIAN FILTER
         medSlide = medfilt(slice, 9)
         # DETERMINE THRESHOLD FLUX VALUE
@@ -568,8 +568,8 @@ class detect_order_edges(_base_detect):
         threshold = minThreshold
 
         # CUT A MEDIAN COLLAPSED SLICE
-        slice = cut_image_slice(log=self.log, frame=self.flatFrame,
-                                width=sliceWidth, length=sliceLength, x=x, y=y, median=True, plot=False)
+        slice, x_offset, y_centre = cut_image_slice(log=self.log, frame=self.flatFrame,
+                                                    width=sliceWidth, length=sliceLength, x=x, y=y, median=True, plot=False)
         if slice is None:
             return orderData
 

--- a/soxspipe/commonutils/dispersion_map_to_pixel_arrays.py
+++ b/soxspipe/commonutils/dispersion_map_to_pixel_arrays.py
@@ -24,7 +24,8 @@ os.environ['TERM'] = 'vt100'
 def dispersion_map_to_pixel_arrays(
         log,
         dispersionMapPath,
-        orderPixelTable):
+        orderPixelTable,
+        removeOffDetectorLocation=True):
     """*use a first-guess dispersion map to append x,y fits to line-list data frame.* 
 
     Return a line-list with x,y fits given a first guess dispersion map.*
@@ -34,6 +35,7 @@ def dispersion_map_to_pixel_arrays(
     - `log` -- logger
     - `dispersionMapPath` -- path to the dispersion map
     - `orderPixelTable` -- a data-frame including 'order', 'wavelength' and 'slit_pos' columns
+    - `removeOffDetectorLocation` -- if data points are found to lie off the detector plane then remove them from the resutls. Default *True*
 
     **Usage:**
 
@@ -90,10 +92,11 @@ def dispersion_map_to_pixel_arrays(
     orderPixelTable["fit_x"] = poly['x'](orderPixelTable, *coeff['x'])
     orderPixelTable["fit_y"] = poly['y'](orderPixelTable, *coeff['y'])
 
-    # FILTER DATA FRAME
-    # FIRST CREATE THE MASK
-    mask = (orderPixelTable["fit_x"] > 0) & (orderPixelTable["fit_y"] > 0)
-    orderPixelTable = orderPixelTable.loc[mask]
+    if removeOffDetectorLocation:
+        # FILTER DATA FRAME
+        # FIRST CREATE THE MASK
+        mask = (orderPixelTable["fit_x"] > 0) & (orderPixelTable["fit_y"] > 0)
+        orderPixelTable = orderPixelTable.loc[mask]
 
     log.debug('completed the ``dispersion_map_to_pixel_arrays`` function')
     return orderPixelTable

--- a/soxspipe/commonutils/toolkit.py
+++ b/soxspipe/commonutils/toolkit.py
@@ -294,6 +294,10 @@ def unpack_order_table(
     poly = chebyshev_order_xy_polynomials(log=log, y_deg=int(orderPolyTable.iloc[0]["degy_cent"]), order_deg=int(orderPolyTable.iloc[0]["degorder_cent"]), orderCol="order", yCol="ycoord").poly
     orderPixelTable["xcoord_centre"] = poly(orderPixelTable, *cent_coeff)
 
+    std_coeff = [float(v) for k, v in orderPolyTable.iloc[0].items() if "std_" in k]
+    poly = chebyshev_order_xy_polynomials(log=log, y_deg=int(orderPolyTable.iloc[0]["degy_cent"]), order_deg=int(orderPolyTable.iloc[0]["degorder_cent"]), orderCol="order", yCol="ycoord").poly
+    orderPixelTable["std"] = poly(orderPixelTable, *std_coeff)
+
     if "degy_edgeup" in orderPolyTable.columns:
         upper_coeff = [float(v) for k, v in orderPolyTable.iloc[0].items() if "edgeup_" in k]
         poly = chebyshev_order_xy_polynomials(log=log, y_deg=int(orderPolyTable.iloc[0]["degy_edgeup"]), order_deg=int(orderPolyTable.iloc[0]["degorder_edgeup"]), orderCol="order", yCol="ycoord").poly

--- a/soxspipe/commonutils/toolkit.py
+++ b/soxspipe/commonutils/toolkit.py
@@ -77,10 +77,12 @@ def cut_image_slice(
 
     # CHECK WE ARE NOT GOING BEYOND BOUNDS OF FRAME
     if (x > frame.shape[1] - halfSlice) or (y > frame.shape[0] - halfwidth) or (x < halfSlice) or (y < halfwidth):
-        return None
+        return None, None, None
 
+    x_offset = int(x - halfSlice)
     slice = frame[int(y - halfwidth):int(y + halfwidth + 1),
-                  int(x - halfSlice):int(x + halfSlice)]
+                  x_offset:int(x + halfSlice)]
+    y_centre = (int(y + halfwidth + 1) + int(y - halfwidth)) / 2
 
     if median:
         slice = ma.median(slice, axis=0)
@@ -95,7 +97,7 @@ def cut_image_slice(
         plt.show()
 
     log.debug('completed the ``cut_image_slice`` function')
-    return slice
+    return slice, x_offset, y_centre
 
 
 def quicklook_image(

--- a/soxspipe/commonutils/toolkit.py
+++ b/soxspipe/commonutils/toolkit.py
@@ -295,8 +295,9 @@ def unpack_order_table(
     orderPixelTable["xcoord_centre"] = poly(orderPixelTable, *cent_coeff)
 
     std_coeff = [float(v) for k, v in orderPolyTable.iloc[0].items() if "std_" in k]
-    poly = chebyshev_order_xy_polynomials(log=log, y_deg=int(orderPolyTable.iloc[0]["degy_cent"]), order_deg=int(orderPolyTable.iloc[0]["degorder_cent"]), orderCol="order", yCol="ycoord").poly
-    orderPixelTable["std"] = poly(orderPixelTable, *std_coeff)
+    if len(std_coeff):
+        poly = chebyshev_order_xy_polynomials(log=log, y_deg=int(orderPolyTable.iloc[0]["degy_cent"]), order_deg=int(orderPolyTable.iloc[0]["degorder_cent"]), orderCol="order", yCol="ycoord").poly
+        orderPixelTable["std"] = poly(orderPixelTable, *std_coeff)
 
     if "degy_edgeup" in orderPolyTable.columns:
         upper_coeff = [float(v) for k, v in orderPolyTable.iloc[0].items() if "edgeup_" in k]

--- a/soxspipe/test_settings_xsh.yaml
+++ b/soxspipe/test_settings_xsh.yaml
@@ -47,7 +47,7 @@ soxs-order-centre:
     y-deg: 5
     order-deg: 5
     poly-fitting-residual-clipping-sigma: 4.0
-    clipping-iteration-limit: 10
+    clipping-iteration-limit: 1
 
 soxs-spatial-solution:
     pixel-window-size: 10

--- a/soxspipe/test_settings_xsh.yaml
+++ b/soxspipe/test_settings_xsh.yaml
@@ -46,7 +46,7 @@ soxs-order-centre:
     peak-sigma-limit: 3
     y-deg: 5
     order-deg: 5
-    poly-fitting-residual-clipping-sigma: 2.0
+    poly-fitting-residual-clipping-sigma: 4.0
     clipping-iteration-limit: 10
 
 soxs-spatial-solution:
@@ -76,7 +76,7 @@ soxs-mflat:
     y-deg: 5
     order-deg: 5
     poly-fitting-residual-clipping-sigma: 5.
-    clipping-iteration-limit: 2
+    clipping-iteration-limit: 
     low-sensitivity-clipping-simga: 2
     
 soxs-stare:


### PR DESCRIPTION
During continuum detection, the source profile is now been fitted (globally) and added to the order-table. This is needed for extraction routines.

The plot below shows the order-centre traces from a single pinhole flat lamp with the profile now being fitted and presented as FWHM in the bottom panel. At this point in the reduction cascade, we only have a wavelength solution with no information in the spatial direction; hence the FWHM is presented in pixel units. Not sure yet if the systematic variations in FWHM present across each order is real or a product of sub-optimal fitting. I suspect real. The angular pixel scale may change across the orders?  

[![](https://live.staticflickr.com/65535/52095583261_5f66b09ba7_z.png)](https://live.staticflickr.com/65535/52095583261_5f66b09ba7_o.png)

